### PR TITLE
Check if index is set in response during method call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 All Notable changes to `oauth2-linkedin` will be documented in this file
 
+## 0.4.2 - 2016-11-09
+
+### Added
+- Nothing
+
+### Deprecated
+- Nothing
+
+### Fixed
+- Check if index is set in response during method call
+
+### Removed
+- Nothing
+
+### Security
+- Nothing
+
 ## 0.4.1 - 2016-08-06
 
 ### Added

--- a/src/Provider/LinkedInResourceOwner.php
+++ b/src/Provider/LinkedInResourceOwner.php
@@ -1,11 +1,16 @@
 <?php namespace League\OAuth2\Client\Provider;
 
+use League\OAuth2\Client\Tool\ArrayAccessorTrait;
+
 /**
  * @property array $response
  * @property string $uid
  */
 class LinkedInResourceOwner extends GenericResourceOwner
 {
+
+    use ArrayAccessorTrait;
+
     /**
      * Raw response
      *
@@ -30,7 +35,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getEmail()
     {
-        return $this->getField('emailAddress');
+        return $this->getValueByKey($this->response, 'emailAddress');
     }
 
     /**
@@ -40,7 +45,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getFirstName()
     {
-        return $this->getField('firstName');
+        return $this->getValueByKey($this->response, 'firstName');
     }
 
     /**
@@ -50,7 +55,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getImageurl()
     {
-        return $this->getField('pictureUrl');
+        return $this->getValueByKey($this->response, 'pictureUrl');
     }
 
     /**
@@ -60,7 +65,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getLastName()
     {
-        return $this->getField('lastName');
+        return $this->getValueByKey($this->response, 'lastName');
     }
 
     /**
@@ -70,7 +75,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getId()
     {
-        return $this->getField('id');
+        return $this->getValueByKey($this->response, 'id');
     }
 
     /**
@@ -80,10 +85,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getLocation()
     {
-        if (isset($this->response['location']['name'])) {
-            return $this->response['location']['name'];
-        }
-        return null;
+        return $this->getValueByKey($this->response, 'location.name');
     }
 
     /**
@@ -93,7 +95,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getDescription()
     {
-        return $this->getField('headline');
+        return $this->getValueByKey($this->response, 'headline');
     }
 
     /**
@@ -103,7 +105,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getUrl()
     {
-        return $this->getField('publicProfileUrl');
+        return $this->getValueByKey($this->response, 'publicProfileUrl');
     }
 
     /**
@@ -116,15 +118,4 @@ class LinkedInResourceOwner extends GenericResourceOwner
         return $this->response;
     }
 
-    /**
-     * Returns a field from the response data.
-     *
-     * @param string $key
-     *
-     * @return mixed|null
-     */
-    private function getField($key)
-    {
-        return isset($this->response[$key]) ? $this->response[$key] : null;
-    }
 }

--- a/src/Provider/LinkedInResourceOwner.php
+++ b/src/Provider/LinkedInResourceOwner.php
@@ -30,7 +30,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getEmail()
     {
-        return $this->response['emailAddress'] ?: null;
+        return $this->getField('emailAddress');
     }
 
     /**
@@ -40,7 +40,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getFirstName()
     {
-        return $this->response['firstName'] ?: null;
+        return $this->getField('firstName');
     }
 
     /**
@@ -50,7 +50,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getImageurl()
     {
-        return $this->response['pictureUrl'] ?: null;
+        return $this->getField('pictureUrl');
     }
 
     /**
@@ -60,7 +60,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getLastName()
     {
-        return $this->response['lastName'] ?: null;
+        return $this->getField('lastName');
     }
 
     /**
@@ -70,7 +70,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getId()
     {
-        return $this->response['id'] ?: null;
+        return $this->getField('id');
     }
 
     /**
@@ -80,7 +80,10 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getLocation()
     {
-        return $this->response['location']['name'] ?: null;
+        if (isset($this->response['location']['name'])) {
+            return $this->response['location']['name'];
+        }
+        return null;
     }
 
     /**
@@ -90,7 +93,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getDescription()
     {
-        return $this->response['headline'] ?: null;
+        return $this->getField('headline');
     }
 
     /**
@@ -100,7 +103,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getUrl()
     {
-        return $this->response['publicProfileUrl'] ?: null;
+        return $this->getField('publicProfileUrl');
     }
 
     /**
@@ -111,5 +114,17 @@ class LinkedInResourceOwner extends GenericResourceOwner
     public function toArray()
     {
         return $this->response;
+    }
+
+    /**
+     * Returns a field from the response data.
+     *
+     * @param string $key
+     *
+     * @return mixed|null
+     */
+    private function getField($key)
+    {
+        return isset($this->response[$key]) ? $this->response[$key] : null;
     }
 }

--- a/src/Provider/LinkedInResourceOwner.php
+++ b/src/Provider/LinkedInResourceOwner.php
@@ -117,5 +117,4 @@ class LinkedInResourceOwner extends GenericResourceOwner
     {
         return $this->response;
     }
-
 }

--- a/test/src/Provider/LinkedInTest.php
+++ b/test/src/Provider/LinkedInTest.php
@@ -129,6 +129,50 @@ class LinkedinTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($description, $user->toArray()['headline']);
     }
 
+    public function testMissingUserData()
+    {
+        $email = uniqid();
+        $userId = rand(1000,9999);
+        $firstName = uniqid();
+        $lastName = uniqid();
+        $location = uniqid();
+        $url = uniqid();
+        $description = uniqid();
+
+        $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
+        $postResponse->shouldReceive('getBody')->andReturn('{"access_token": "mock_access_token", "expires_in": 3600}');
+        $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+
+        $userResponse = m::mock('Psr\Http\Message\ResponseInterface');
+        $userResponse->shouldReceive('getBody')->andReturn('{"id": '.$userId.', "firstName": "'.$firstName.'", "lastName": "'.$lastName.'", "emailAddress": "'.$email.'", "location": { "name": "'.$location.'" }, "headline": "'.$description.'", "publicProfileUrl": "'.$url.'"}');
+        $userResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+
+        $client = m::mock('GuzzleHttp\ClientInterface');
+        $client->shouldReceive('send')
+            ->times(2)
+            ->andReturn($postResponse, $userResponse);
+        $this->provider->setHttpClient($client);
+
+        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $user = $this->provider->getResourceOwner($token);
+
+        $this->assertEquals($email, $user->getEmail());
+        $this->assertEquals($email, $user->toArray()['emailAddress']);
+        $this->assertEquals($userId, $user->getId());
+        $this->assertEquals($userId, $user->toArray()['id']);
+        $this->assertEquals($firstName, $user->getFirstName());
+        $this->assertEquals($firstName, $user->toArray()['firstName']);
+        $this->assertEquals($lastName, $user->GeTlAsTnAmE()); // https://github.com/thephpleague/oauth2-linkedin/issues/4
+        $this->assertEquals($lastName, $user->toArray()['lastName']);
+        $this->assertEquals(null, $user->getImageurl());
+        $this->assertEquals($location, $user->getLocation());
+        $this->assertEquals($location, $user->toArray()['location']['name']);
+        $this->assertEquals($url, $user->getUrl());
+        $this->assertEquals($url, $user->toArray()['publicProfileUrl']);
+        $this->assertEquals($description, $user->getDescription());
+        $this->assertEquals($description, $user->toArray()['headline']);
+    }
+
     /**
      * @expectedException League\OAuth2\Client\Provider\Exception\IdentityProviderException
      **/


### PR DESCRIPTION
The LinkedIn api does not provide fields who are not set, i.e if you don't have an profile picture the field "pictureUrl" is not present in the api response.

If the field isn't present and using the method "getImageurl()" an exception is thrown.

I used the same method the FacebookUser from oauth2-facebook is using.

About the tests: I'm not very familiar with php unittests i hope copying the testUserData and modifying it is okay.