### PR TITLE
Use only LinkedIn API v2 with new default scope 'r_liteprofile'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {
+        "ext-json": "*",
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.9",
         "squizlabs/php_codesniffer": "~2.0"

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -17,27 +17,17 @@ class LinkedIn extends AbstractProvider
      *
      * @var array
      */
-    public $defaultScopes = [];
+    public $defaultScopes = ['r_liteprofile'];
 
-    /**
-     * Preferred resource owner version.
-     *
-     * Options: 1,2
-     *
-     * @var integer
-     */
-    public $resourceOwnerVersion = 1;
 
     /**
      * Requested fields in scope, seeded with default values
      *
      * @var array
-     * @see https://developer.linkedin.com/docs/fields/basic-profile
+     * @see https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin?context=linkedin/consumer/context#response-body-schema
      */
     protected $fields = [
-        'id', 'email-address', 'first-name', 'last-name', 'headline',
-        'location', 'industry', 'picture-url', 'public-profile-url',
-        'summary',
+        'id', 'firstName', 'lastName', 'profilePicture'
     ];
 
     /**
@@ -99,13 +89,7 @@ class LinkedIn extends AbstractProvider
      */
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
-        $fields = implode(',', $this->fields);
-
-        if ($this->resourceOwnerVersion == 1) {
-            return 'https://api.linkedin.com/v1/people/~:('.$fields.')?format=json';
-        }
-
-        return 'https://api.linkedin.com/v2/me?fields='.$fields;
+        return 'https://api.linkedin.com/v2/me?fields=' . implode(',', $this->fields);
     }
 
     /**
@@ -162,15 +146,6 @@ class LinkedIn extends AbstractProvider
         return $this->fields;
     }
 
-    /**
-     * Returns the preferred resource owner version.
-     *
-     * @return integer
-     */
-    public function getResourceOwnerVersion()
-    {
-        return $this->resourceOwnerVersion;
-    }
 
     /**
      * Updates the requested fields in scope.
@@ -182,24 +157,6 @@ class LinkedIn extends AbstractProvider
     public function withFields(array $fields)
     {
         $this->fields = $fields;
-
-        return $this;
-    }
-
-    /**
-     * Updates the preferred resource owner version.
-     *
-     * @param integer $resourceOwnerVersion
-     *
-     * @return LinkedIn
-     */
-    public function withResourceOwnerVersion($resourceOwnerVersion)
-    {
-        $resourceOwnerVersion = (int) $resourceOwnerVersion;
-
-        if (in_array($resourceOwnerVersion, [1, 2])) {
-            $this->resourceOwnerVersion = $resourceOwnerVersion;
-        }
 
         return $this;
     }

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -17,7 +17,7 @@ class LinkedIn extends AbstractProvider
      *
      * @var array
      */
-    public $defaultScopes = ['r_liteprofile', 'r_emailAddress'];
+    public $defaultScopes = ['r_liteprofile', 'r_emailaddress'];
 
     /**
      * Requested fields in scope, seeded with default values

--- a/src/Provider/LinkedInResourceOwner.php
+++ b/src/Provider/LinkedInResourceOwner.php
@@ -38,15 +38,6 @@ class LinkedInResourceOwner extends GenericResourceOwner
         return $this->getValueByKey($this->response, (string) $key);
     }
 
-    /**
-     * Get user email
-     *
-     * @return string|null
-     */
-    public function getEmail()
-    {
-        return $this->getAttribute('emailAddress');
-    }
 
     /**
      * Get user firstname
@@ -65,7 +56,7 @@ class LinkedInResourceOwner extends GenericResourceOwner
      */
     public function getImageurl()
     {
-        return $this->getAttribute('pictureUrl');
+        return $this->getAttribute('profilePicture');
     }
 
     /**
@@ -88,45 +79,6 @@ class LinkedInResourceOwner extends GenericResourceOwner
         return $this->getAttribute('id');
     }
 
-    /**
-     * Get user location
-     *
-     * @return string|null
-     */
-    public function getLocation()
-    {
-        return $this->getAttribute('location.name');
-    }
-
-    /**
-     * Get user description
-     *
-     * @return string|null
-     */
-    public function getDescription()
-    {
-        return $this->getAttribute('headline');
-    }
-
-    /**
-     * Get user url
-     *
-     * @return string|null
-     */
-    public function getUrl()
-    {
-        return $this->getAttribute('publicProfileUrl');
-    }
-
-    /**
-     * Get user summary
-     *
-     * @return string|null
-     */
-    public function getSummary()
-    {
-        return $this->getAttribute('summary');
-    }
 
     /**
      * Return all of the owner details available as an array.

--- a/test/api_responses/email.json
+++ b/test/api_responses/email.json
@@ -1,0 +1,13 @@
+{
+  "elements": [
+    {
+      "handle": "urn:li:emailAddress:",
+      "state": "CONFIRMED",
+      "type": "EMAIL",
+      "handle~": {
+        "emailAddress": "resource-owner@example.com"
+      },
+      "primary": true
+    }
+  ]
+}

--- a/test/api_responses/me.json
+++ b/test/api_responses/me.json
@@ -1,0 +1,185 @@
+{
+  "localizedLastName": "Doe",
+  "profilePicture": {
+    "displayImage": "urn:li:digitalmediaAsset:",
+    "displayImage~": {
+      "elements": [
+        {
+          "artifact": "urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_100_100)",
+          "authorizationMethod": "PUBLIC",
+          "data": {
+            "com.linkedin.digitalmedia.mediaartifact.StillImage": {
+              "storageSize": {
+                "width": 100,
+                "height": 100
+              },
+              "storageAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              },
+              "mediaType": "image/jpeg",
+              "rawCodecSpec": {
+                "name": "jpeg",
+                "type": "image"
+              },
+              "displaySize": {
+                "uom": "PX",
+                "width": 100.0,
+                "height": 100.0
+              },
+              "displayAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              }
+            }
+          },
+          "identifiers": [
+            {
+              "identifier": "http://example.com/avatar_100_100.jpeg",
+              "file": "urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_100_100,0)",
+              "index": 0,
+              "mediaType": "image/jpeg",
+              "identifierType": "EXTERNAL_URL",
+              "identifierExpiresInSeconds": 1561593600
+            }
+          ]
+        },
+        {
+          "artifact": "urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_200_200)",
+          "authorizationMethod": "PUBLIC",
+          "data": {
+            "com.linkedin.digitalmedia.mediaartifact.StillImage": {
+              "storageSize": {
+                "width": 200,
+                "height": 200
+              },
+              "storageAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              },
+              "mediaType": "image/jpeg",
+              "rawCodecSpec": {
+                "name": "jpeg",
+                "type": "image"
+              },
+              "displaySize": {
+                "uom": "PX",
+                "width": 200.0,
+                "height": 200.0
+              },
+              "displayAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              }
+            }
+          },
+          "identifiers": [
+            {
+              "identifier": "http://example.com/avatar_200_200.jpeg",
+              "file": "urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_200_200,0)",
+              "index": 0,
+              "mediaType": "image/jpeg",
+              "identifierType": "EXTERNAL_URL",
+              "identifierExpiresInSeconds": 1561593600
+            }
+          ]
+        },
+        {
+          "artifact": "urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_400_400)",
+          "authorizationMethod": "PUBLIC",
+          "data": {
+            "com.linkedin.digitalmedia.mediaartifact.StillImage": {
+              "storageSize": {
+                "width": 400,
+                "height": 400
+              },
+              "storageAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              },
+              "mediaType": "image/jpeg",
+              "rawCodecSpec": {
+                "name": "jpeg",
+                "type": "image"
+              },
+              "displaySize": {
+                "uom": "PX",
+                "width": 400.0,
+                "height": 400.0
+              },
+              "displayAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              }
+            }
+          },
+          "identifiers": [
+            {
+              "identifier": "http://example.com/avatar_400_400.jpeg",
+              "file": "urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_400_400,0)",
+              "index": 0,
+              "mediaType": "image/jpeg",
+              "identifierType": "EXTERNAL_URL",
+              "identifierExpiresInSeconds": 1561593600
+            }
+          ]
+        },
+        {
+          "artifact": "urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_800_800)",
+          "authorizationMethod": "PUBLIC",
+          "data": {
+            "com.linkedin.digitalmedia.mediaartifact.StillImage": {
+              "storageSize": {
+                "width": 800,
+                "height": 800
+              },
+              "storageAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              },
+              "mediaType": "image/jpeg",
+              "rawCodecSpec": {
+                "name": "jpeg",
+                "type": "image"
+              },
+              "displaySize": {
+                "uom": "PX",
+                "width": 800.0,
+                "height": 800.0
+              },
+              "displayAspectRatio": {
+                "widthAspect": 1.0,
+                "heightAspect": 1.0,
+                "formatted": "1.00:1.00"
+              }
+            }
+          },
+          "identifiers": [
+            {
+              "identifier": "http://example.com/avatar_800_800.jpeg",
+              "file": "urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_800_800,0)",
+              "index": 0,
+              "mediaType": "image/jpeg",
+              "identifierType": "EXTERNAL_URL",
+              "identifierExpiresInSeconds": 1561593600
+            }
+          ]
+        }
+      ],
+      "paging": {
+        "count": 10,
+        "start": 0,
+        "links": []
+      }
+    }
+  },
+  "id": "abcdef1234",
+  "localizedFirstName": "John"
+}


### PR DESCRIPTION
Use only LinkedIn API v2 with new default scope 'r_liteprofile' because LinkedIn is going to stop Sign In via OAuth1.0.