### PR TITLE
Attempt to set email in resource owner

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.9",
-        "squizlabs/php_codesniffer": "~2.0"
+        "squizlabs/php_codesniffer": "~2.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Provider/Exception/LinkedInAccessDeniedException.php
+++ b/src/Provider/Exception/LinkedInAccessDeniedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace League\OAuth2\Client\Provider\Exception;
+
+class LinkedInAccessDeniedException extends IdentityProviderException
+{
+
+}

--- a/src/Provider/LinkedInResourceOwner.php
+++ b/src/Provider/LinkedInResourceOwner.php
@@ -26,13 +26,20 @@ class LinkedInResourceOwner extends GenericResourceOwner
     protected $sortedProfilePictures = [];
 
     /**
+     * @var string|null
+     */
+    private $email;
+
+    /**
      * Creates new resource owner.
      *
      * @param array  $response
+     * @param string|null $email
      */
-    public function __construct(array $response = array())
+    public function __construct(array $response = array(), $email = null)
     {
         $this->response = $response;
+        $this->email = $email;
         $this->setSortedProfilePictures();
     }
 
@@ -136,6 +143,16 @@ class LinkedInResourceOwner extends GenericResourceOwner
         $vanityName = $this->getAttribute('vanityName');
 
         return $vanityName ? sprintf('https://www.linkedin.com/in/%s', $vanityName) : null;
+    }
+
+    /**
+     * Get user email, if available
+     *
+     * @return string|null
+     */
+    public function getEmail()
+    {
+        return $this->email;
     }
 
     /**

--- a/test/src/Provider/LinkedInTest.php
+++ b/test/src/Provider/LinkedInTest.php
@@ -126,6 +126,7 @@ class LinkedinTest extends \PHPUnit_Framework_TestCase
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->andReturn('{"access_token": "mock_access_token", "expires_in": 3600, "refresh_token": "mock_refresh_token", "refresh_token_expires_in": 7200}');
         $response->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $response->shouldReceive('getStatusCode')->andReturn(200);
 
         $client = m::mock('GuzzleHttp\ClientInterface');
         $client->shouldReceive('send')->times(1)->andReturn($response);
@@ -145,21 +146,29 @@ class LinkedinTest extends \PHPUnit_Framework_TestCase
     public function testUserData()
     {
         $apiProfileResponse = json_decode(file_get_contents(__DIR__.'/../../api_responses/me.json'), true);
+        $apiEmailResponse = json_decode(file_get_contents(__DIR__.'/../../api_responses/email.json'), true);
         $somethingExtra = ['more' => uniqid()];
         $apiProfileResponse['somethingExtra'] = $somethingExtra;
 
         $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
         $postResponse->shouldReceive('getBody')->andReturn('{"access_token": "mock_access_token", "expires_in": 3600}');
         $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $postResponse->shouldReceive('getStatusCode')->andReturn(200);
 
         $userResponse = m::mock('Psr\Http\Message\ResponseInterface');
         $userResponse->shouldReceive('getBody')->andReturn(json_encode($apiProfileResponse));
         $userResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $userResponse->shouldReceive('getStatusCode')->andReturn(200);
+
+        $emailResponse = m::mock('Psr\Http\Message\ResponseInterface');
+        $emailResponse->shouldReceive('getBody')->andReturn(json_encode($apiEmailResponse));
+        $emailResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $emailResponse->shouldReceive('getStatusCode')->andReturn(200);
 
         $client = m::mock('GuzzleHttp\ClientInterface');
         $client->shouldReceive('send')
-            ->times(2)
-            ->andReturn($postResponse, $userResponse);
+            ->times(3)
+            ->andReturn($postResponse, $userResponse, $emailResponse);
         $this->provider->setHttpClient($client);
 
         $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
@@ -173,6 +182,7 @@ class LinkedinTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Doe', $user->toArray()['localizedLastName']);
         $this->assertEquals('http://example.com/avatar_800_800.jpeg', $user->getImageUrl());
         $this->assertEquals('https://www.linkedin.com/in/john-doe', $user->getUrl());
+        $this->assertEquals('resource-owner@example.com', $user->getEmail());
         $this->assertEquals($somethingExtra, $user->getAttribute('somethingExtra'));
         $this->assertEquals($somethingExtra, $user->toArray()['somethingExtra']);
         $this->assertEquals($somethingExtra['more'], $user->getAttribute('somethingExtra.more'));
@@ -187,6 +197,7 @@ class LinkedinTest extends \PHPUnit_Framework_TestCase
         $firstName = uniqid();
         $lastName = uniqid();
         $apiProfileResponse = json_decode(file_get_contents(__DIR__.'/../../api_responses/me.json'), true);
+        $apiEmailResponse = json_decode(file_get_contents(__DIR__.'/../../api_responses/email.json'), true);
         $apiProfileResponse['id'] = $userId;
         $apiProfileResponse['localizedFirstName'] = $firstName;
         $apiProfileResponse['localizedLastName'] = $lastName;
@@ -196,15 +207,22 @@ class LinkedinTest extends \PHPUnit_Framework_TestCase
         $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
         $postResponse->shouldReceive('getBody')->andReturn('{"access_token": "mock_access_token", "expires_in": 3600}');
         $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $postResponse->shouldReceive('getStatusCode')->andReturn(200);
 
         $userResponse = m::mock('Psr\Http\Message\ResponseInterface');
         $userResponse->shouldReceive('getBody')->andReturn(json_encode($apiProfileResponse));
         $userResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $userResponse->shouldReceive('getStatusCode')->andReturn(200);
+
+        $emailResponse = m::mock('Psr\Http\Message\ResponseInterface');
+        $emailResponse->shouldReceive('getBody')->andReturn(json_encode($apiEmailResponse));
+        $emailResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $emailResponse->shouldReceive('getStatusCode')->andReturn(200);
 
         $client = m::mock('GuzzleHttp\ClientInterface');
         $client->shouldReceive('send')
-            ->times(2)
-            ->andReturn($postResponse, $userResponse);
+            ->times(3)
+            ->andReturn($postResponse, $userResponse, $emailResponse);
         $this->provider->setHttpClient($client);
 
         $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
@@ -227,10 +245,12 @@ class LinkedinTest extends \PHPUnit_Framework_TestCase
         $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
         $postResponse->shouldReceive('getBody')->andReturn('{"access_token": "mock_access_token", "expires_in": 3600}');
         $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $postResponse->shouldReceive('getStatusCode')->andReturn(200);
 
         $userResponse = m::mock('Psr\Http\Message\ResponseInterface');
         $userResponse->shouldReceive('getBody')->andReturn(json_encode($apiEmailResponse));
         $userResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $userResponse->shouldReceive('getStatusCode')->andReturn(200);
 
         $client = m::mock('GuzzleHttp\ClientInterface');
         $client->shouldReceive('send')
@@ -250,15 +270,17 @@ class LinkedinTest extends \PHPUnit_Framework_TestCase
             $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
             $postResponse->shouldReceive('getBody')->andReturn('{"access_token": "mock_access_token", "expires_in": 3600}');
             $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+            $postResponse->shouldReceive('getStatusCode')->andReturn(200);
 
-            $userResponse = m::mock('Psr\Http\Message\ResponseInterface');
-            $userResponse->shouldReceive('getBody')->andReturn(json_encode($apiEmailResponse));
-            $userResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+            $emailResponse = m::mock('Psr\Http\Message\ResponseInterface');
+            $emailResponse->shouldReceive('getBody')->andReturn(json_encode($apiEmailResponse));
+            $emailResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+            $emailResponse->shouldReceive('getStatusCode')->andReturn(200);
 
             $client = m::mock('GuzzleHttp\ClientInterface');
             $client->shouldReceive('send')
                 ->times(2)
-                ->andReturn($postResponse, $userResponse);
+                ->andReturn($postResponse, $emailResponse);
             $this->provider->setHttpClient($client);
 
             $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
@@ -266,6 +288,70 @@ class LinkedinTest extends \PHPUnit_Framework_TestCase
 
             $this->assertNull($email);
         }
+    }
+
+    public function testResourceOwnerEmailNullWhenNotAuthorized()
+    {
+        $apiProfileResponse = json_decode(file_get_contents(__DIR__.'/../../api_responses/me.json'), true);
+
+        $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
+        $postResponse->shouldReceive('getBody')->andReturn('{"access_token": "mock_access_token", "expires_in": 3600}');
+        $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $postResponse->shouldReceive('getStatusCode')->andReturn(200);
+
+        $userResponse = m::mock('Psr\Http\Message\ResponseInterface');
+        $userResponse->shouldReceive('getBody')->andReturn(json_encode($apiProfileResponse));
+        $userResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $userResponse->shouldReceive('getStatusCode')->andReturn(200);
+
+        $emailResponse = m::mock('Psr\Http\Message\ResponseInterface');
+        $emailResponse->shouldReceive('getBody')->andReturn('{"message": "Not enough permissions to access: GET-members /clientAwareMemberHandles","status":403,"serviceErrorCode":100}');
+        $emailResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $emailResponse->shouldReceive('getStatusCode')->andReturn(403);
+
+        $client = m::mock('GuzzleHttp\ClientInterface');
+        $client->shouldReceive('send')
+            ->times(3)
+            ->andReturn($postResponse, $userResponse, $emailResponse);
+        $this->provider->setHttpClient($client);
+
+        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+
+        $user = $this->provider->getResourceOwner($token);
+
+        $this->assertNull($user->getEmail());
+
+        $this->assertEquals('abcdef1234', $user->getId());
+        $this->assertEquals('John', $user->getFirstName());
+        $this->assertEquals('Doe', $user->getLastName());
+        $this->assertEquals('http://example.com/avatar_800_800.jpeg', $user->getImageUrl());
+        $this->assertEquals('https://www.linkedin.com/in/john-doe', $user->getUrl());
+    }
+
+    /**
+     * @expectedException League\OAuth2\Client\Provider\Exception\LinkedInAccessDeniedException
+     */
+    public function testExceptionThrownWhenEmailIsNotAuthorizedButRequestedFromAdapter()
+    {
+        $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
+        $postResponse->shouldReceive('getBody')->andReturn('{"access_token": "mock_access_token", "expires_in": 3600}');
+        $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $postResponse->shouldReceive('getStatusCode')->andReturn(200);
+
+        $emailResponse = m::mock('Psr\Http\Message\ResponseInterface');
+        $emailResponse->shouldReceive('getBody')->andReturn('{"message": "Not enough permissions to access: GET-members /clientAwareMemberHandles","status":403,"serviceErrorCode":100}');
+        $emailResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $emailResponse->shouldReceive('getStatusCode')->andReturn(403);
+
+        $client = m::mock('GuzzleHttp\ClientInterface');
+        $client->shouldReceive('send')
+            ->times(2)
+            ->andReturn($postResponse, $emailResponse);
+        $this->provider->setHttpClient($client);
+
+        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+
+        $this->provider->getResourceOwnerEmail($token);
     }
 
     /**
@@ -276,7 +362,7 @@ class LinkedinTest extends \PHPUnit_Framework_TestCase
         $message = uniqid();
         $status = rand(400,600);
         $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
-        $postResponse->shouldReceive('getBody')->andReturn('{"error_description": "'.$message.'","error": "invalid_request"}');
+        $postResponse->shouldReceive('getBody')->andReturn('{"message": "'.$message.'","status": '.$status.', "serviceErrorCode": 100}');
         $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
         $postResponse->shouldReceive('getStatusCode')->andReturn($status);
 


### PR DESCRIPTION
Following up discussion in #29 implementation of "getEmail" on ResourceOwner which:
- does not use additional configuration options on the Provider
- automatically tries to get the email address, but emulates the "return null if not available" behaviour of other providers
- hides access denied when downloading email implicitly when calling getResourceOwner, but throws on any other failure from API
- throws on access denied when getResourceOwnerEmail is called explicitly.

Potential problems:
- always two requests are done when resource data is downloaded, and the developer has no way of disabling email download, even if they know it will fail
- users will not be getting email and no warning or error if r_emailscope is missing, but that behaviour is consistent with other providers.