### PR TITLE
Fix issue where key is preserved

### DIFF
--- a/src/Provider/LinkedInResourceOwner.php
+++ b/src/Provider/LinkedInResourceOwner.php
@@ -82,8 +82,14 @@ class LinkedInResourceOwner extends GenericResourceOwner
         $pictures = array_filter($this->sortedProfilePictures, function ($picture) use ($size) {
             return isset($picture['width']) && $picture['width'] == $size;
         });
+        
+        if (count($pictures) < 1) {
+            return null;   
+        }
+        
+        $picture = array_shift($pictures);
 
-        return count($pictures) ? $pictures[0] : null;
+        return $picture;
     }
 
     /**


### PR DESCRIPTION
array_filter will preserve keys. Therefore $pictures[0] won't actually be set if you're filtering down to a key other than the first.