### PR TITLE
fix: move `namespace` declaration to new line

### DIFF
--- a/src/Provider/LinkedInResourceOwner.php
+++ b/src/Provider/LinkedInResourceOwner.php
@@ -1,4 +1,6 @@
-<?php namespace League\OAuth2\Client\Provider;
+<?php
+
+namespace League\OAuth2\Client\Provider;
 
 use League\OAuth2\Client\Tool\ArrayAccessorTrait;
 


### PR DESCRIPTION
This PR moves the `namespace` declaration in `LinkedInResourceOwner.php` to its own line, as per [PSR-12](https://www.php-fig.org/psr/psr-12/)

Has the benefit of fixing a conflict with https://github.com/BrianHenryIE/strauss/ v0.14.1